### PR TITLE
Support for using the CPU as a device

### DIFF
--- a/CaffeLoader.py
+++ b/CaffeLoader.py
@@ -108,19 +108,17 @@ class ModelParallel(nn.Module):
         self.chunks = chunks
         self.device_list = device_list
                
-    def c(self, input, i)
-        if self.chunks[i].is_cuda() and 'cpu' in self.device_list[i]:
-            if input.type() == 'torch.FloatTensor':
-                input = input.type('torch.cuda.FloatTensor')
-        elif not self.chunks[i].is_cuda() and 'cuda' in self.device_list[i]:
-             if input.type() == 'torch.cuda.FloatTensor':
+    def c(self, input, i):
+        if input.type() == 'torch.FloatTensor' and 'cuda' in self.device_list[i]:
+            input = input.type('torch.cuda.FloatTensor')
+        elif input.type() == 'torch.cuda.FloatTensor' and 'cpu' in self.device_list[i]:
                 input = input.type('torch.FloatTensor')
         return input
         
     def forward(self, input):
         for i, chunk in enumerate(self.chunks):
             if i < len(self.chunks) -1:
-               input = c(chunk(c(input, i).to(self.device_list[i])), i+1).to(self.device_list[i+1])
+               input = self.c(chunk(self.c(input, i).to(self.device_list[i])), i+1).to(self.device_list[i+1])
             else: 
                input = chunk(input)
         return input
@@ -221,7 +219,7 @@ def loadCaffemodel(model_file, pooling, use_gpu, disable_check):
     print("Successfully loaded " + str(model_file))
 
     # Maybe convert the model to cuda now, to avoid later issues
-    if "c" not in str(use_gpu):
+    if "c" not in str(use_gpu) or 'c' not in str(use_gpu[0]).lower():
         cnn = cnn.cuda()
     cnn = cnn.features 
 

--- a/CaffeLoader.py
+++ b/CaffeLoader.py
@@ -107,29 +107,24 @@ class ModelParallel(nn.Module):
         super(ModelParallel, self).__init__()
         self.chunks = chunks
         self.device_list = device_list
-        
-        
-    def convert(self, input, device):
-        if 'cpu' in device:
-            if input.type() == 'torch.cuda.FloatTensor':
-                input = input.type('torch.FloatTensor')
-        elif 'cuda' in device:
+               
+    def c(self, input, i)
+        if self.chunks[i].is_cuda() and 'cpu' in self.device_list[i]:
             if input.type() == 'torch.FloatTensor':
                 input = input.type('torch.cuda.FloatTensor')
+        elif not self.chunks[i].is_cuda() and 'cuda' in self.device_list[i]:
+             if input.type() == 'torch.cuda.FloatTensor':
+                input = input.type('torch.FloatTensor')
         return input
-
-
+        
     def forward(self, input):
         for i, chunk in enumerate(self.chunks):
             if i < len(self.chunks) -1:
-               input = chunk( convert(input, device_list[i]).to(self.device_list[i]) )
-               input = convert(input, device_list[i+1]).to(self.device_list[i+1])
+               input = c(chunk(c(input, i).to(self.device_list[i])), i+1).to(self.device_list[i+1])
             else: 
                input = chunk(input)
         return input
       
-       
-
 
 
 def buildSequential(channel_list, pooling):

--- a/CaffeLoader.py
+++ b/CaffeLoader.py
@@ -107,14 +107,28 @@ class ModelParallel(nn.Module):
         super(ModelParallel, self).__init__()
         self.chunks = chunks
         self.device_list = device_list
+        
+        
+    def convert(self, input, device):
+        if 'cpu' in device:
+            if input.type() == 'torch.cuda.FloatTensor':
+                input = input.type('torch.FloatTensor')
+        elif 'cuda' in device:
+            if input.type() == 'torch.FloatTensor':
+                input = input.type('torch.cuda.FloatTensor')
+        return input
+
 
     def forward(self, input):
         for i, chunk in enumerate(self.chunks):
             if i < len(self.chunks) -1:
-               input = chunk(input.to(self.device_list[i]) ).to(self.device_list[i+1])
+               input = chunk( convert(input, device_list[i]).to(self.device_list[i]) )
+               input = convert(input, device_list[i+1]).to(self.device_list[i+1])
             else: 
                input = chunk(input)
         return input
+      
+       
 
 
 

--- a/neural_style.py
+++ b/neural_style.py
@@ -285,7 +285,24 @@ def setup_gpu():
     else: 
         multidevice = False
         backward_device = "cuda:" + str(params.gpu)
-    if "c" not in str(params.gpu):
+        
+    if "c" in str(params.gpu) and "," in str(params.gpu):
+        if params.backend == 'cudnn': 
+            torch.backends.cudnn.enabled = True
+            if params.cudnn_autotune:
+                torch.backends.cudnn.benchmark = True  
+        else:
+            torch.backends.cudnn.enabled = False
+        if params.backend =='mkl': 
+           torch.backends.mkl.enabled = True 
+        if 'cpu' in str(params.gpu[0]).lower()
+            backward_device = "cpu"
+            dtype = torch.cuda.FloatTensor
+        else: 
+             backward_device = "cuda:" + params.gpu[0]
+             dtype = torch.cuda.FloatTensor
+            
+    elif "c" not in str(params.gpu):
         if params.backend == 'cudnn': 
             torch.backends.cudnn.enabled = True
             if params.cudnn_autotune:
@@ -293,6 +310,7 @@ def setup_gpu():
         else:
             torch.backends.cudnn.enabled = False
         dtype = torch.cuda.FloatTensor
+        
     elif "c" in str(params.gpu): 
        if params.backend =='mkl': 
            torch.backends.mkl.enabled = True 


### PR DESCRIPTION
- You can now use the CPU as a device alongside a list of one or more GPUs. 

For example this put the first layer of the model on the CPU, while every other layer is on the GPU:: 

```
python3 neural_style.py -gpu c,0 -image_size 256 -multidevice_strategy 1
```
And this will put the first and last layers of a model on the CPU, while every other layer is on the GPU:
```
python3 neural_style.py -gpu c,0,c -image_size 256 -multidevice_strategy 1,34
```