### PR TITLE
ModelParallel and Backend Improvements

### DIFF
--- a/CaffeLoader.py
+++ b/CaffeLoader.py
@@ -103,7 +103,7 @@ class NIN(nn.Module):
 
         
 
-# Give zero-indexed GPU and CPU devices their Torch name
+# Give a list of zero-indexed GPU and CPU devices their PyTorch name
 def name_devices(input_list):
     device_list = []
     for i, device in enumerate(input_list):
@@ -113,19 +113,19 @@ def name_devices(input_list):
             device_list.append("cpu")
     return device_list
 	
-# Split network into chunks
-def split_net(net, device_splits):		
+# Split a network into chunks
+def split_net(net, net_splits):		
     chunks, cur_chunk = [], nn.Sequential()
     for i, l in enumerate(net):
          cur_chunk.add_module(str(i), net[i])
-         if str(i) in device_splits and device_splits != '':
+         if str(i) in net_splits and net_splits != '':
              del device_splits[0]
              chunks.append(cur_chunk)
              cur_chunk = nn.Sequential()
     chunks.append(cur_chunk)
     return chunks
 		
-# Put net chunks onto devices
+# Put list of nets onto list of devices
 def chunks_to_devices(chunks, device_list):
     for i, chunk in enumerate(chunks):
         chunk.to(device_list[i])

--- a/CaffeLoader.py
+++ b/CaffeLoader.py
@@ -125,7 +125,7 @@ def split_net(net, net_splits):
     chunks.append(cur_chunk)
     return chunks
 		
-# Put list of nets onto list of devices
+# Put list of nets onto different devices
 def chunks_to_devices(chunks, device_list):
     for i, chunk in enumerate(chunks):
         chunk.to(device_list[i])

--- a/CaffeLoader.py
+++ b/CaffeLoader.py
@@ -119,7 +119,7 @@ def split_net(net, net_splits):
     for i, l in enumerate(net):
          cur_chunk.add_module(str(i), net[i])
          if str(i) in net_splits and net_splits != '':
-             del device_splits[0]
+             del net_splits[0]
              chunks.append(cur_chunk)
              cur_chunk = nn.Sequential()
     chunks.append(cur_chunk)

--- a/CaffeLoader.py
+++ b/CaffeLoader.py
@@ -107,7 +107,7 @@ class ModelParallel(nn.Module):
     def __init__(self, net, device_ids, net_splits):
         super(ModelParallel, self).__init__()
         self.device_list = self.name_devices(device_ids.split(','))
-        self.chunks = self.chunks_to_devices(self.split_net(net, net_splits.split(',')), self.device_list)
+        self.chunks = self.chunks_to_devices(self.split_net(net, net_splits.split(',')))
 
     def name_devices(self, input_list):
         device_list = []
@@ -129,9 +129,9 @@ class ModelParallel(nn.Module):
         chunks.append(cur_chunk)
         return chunks
 
-    def chunks_to_devices(self, chunks, device_list):
+    def chunks_to_devices(self, chunks):
         for i, chunk in enumerate(chunks):
-            chunk.to(device_list[i])
+            chunk.to(self.device_list[i])
         return chunks
 
     def c(self, input, i):

--- a/CaffeLoader.py
+++ b/CaffeLoader.py
@@ -238,6 +238,7 @@ def print_loadcaffe(cnn, layerList):
          if c == len(layerList['C']):
              break
 
+	
 # Load the model, and configure pooling layer type
 def loadCaffemodel(model_file, pooling, use_gpu, disable_check):
     cnn, layerList = modelSelector(str(model_file).lower(), pooling)

--- a/CaffeLoader.py
+++ b/CaffeLoader.py
@@ -226,6 +226,7 @@ def modelSelector(model_file, pooling):
         raise ValueError("Model architecture not recognized.")
     return cnn, layerList
 
+
 # Print like Torch7/loadcaffe
 def print_loadcaffe(cnn, layerList):
     c = 0

--- a/CaffeLoader.py
+++ b/CaffeLoader.py
@@ -103,38 +103,36 @@ class NIN(nn.Module):
 
 
 
-def name_devices(input_list):
-    device_list = []
-    for i, device in enumerate(input_list):
-        if str(device).lower() != 'c':
-            device_list.append("cuda:" + str(device))
-        else:
-            device_list.append("cpu")
-    return device_list
-
-def split_net(net, net_splits):
-    chunks, cur_chunk = [], nn.Sequential()
-    for i, l in enumerate(net):
-        cur_chunk.add_module(str(i), net[i])
-        if str(i) in net_splits and net_splits != '':
-            del net_splits[0]
-            chunks.append(cur_chunk)
-            cur_chunk = nn.Sequential()
-    chunks.append(cur_chunk)
-    return chunks
-
-def chunks_to_devices(chunks, device_list):
-    for i, chunk in enumerate(chunks):
-        chunk.to(device_list[i])
-    return chunks
-
-
-
 class ModelParallel(nn.Module):
     def __init__(self, net, device_ids, net_splits):
         super(ModelParallel, self).__init__()
-        self.device_list = name_devices(device_ids.split(','))
-        self.chunks = chunks_to_devices(split_net(net, net_splits.split(',')), self.device_list)
+        self.device_list = self.name_devices(device_ids.split(','))
+        self.chunks = self.chunks_to_devices(self.split_net(net, net_splits.split(',')), self.device_list)
+
+    def name_devices(self, input_list):
+        device_list = []
+        for i, device in enumerate(input_list):
+            if str(device).lower() != 'c':
+                device_list.append("cuda:" + str(device))
+            else:
+                device_list.append("cpu")
+        return device_list
+
+    def split_net(self, net, net_splits):
+        chunks, cur_chunk = [], nn.Sequential()
+        for i, l in enumerate(net):
+            cur_chunk.add_module(str(i), net[i])
+            if str(i) in net_splits and net_splits != '':
+                del net_splits[0]
+                chunks.append(cur_chunk)
+                cur_chunk = nn.Sequential()
+        chunks.append(cur_chunk)
+        return chunks
+
+    def chunks_to_devices(self, chunks, device_list):
+        for i, chunk in enumerate(chunks):
+            chunk.to(device_list[i])
+        return chunks
 
     def c(self, input, i):
         if input.type() == 'torch.FloatTensor' and 'cuda' in self.device_list[i]:

--- a/CaffeLoader.py
+++ b/CaffeLoader.py
@@ -101,12 +101,41 @@ class NIN(nn.Module):
             nn.Softmax(),
         )
 
+        
 
+# Give zero-indexed GPU and CPU devices their Torch name
+def name_devices(input_list):
+    device_list = []
+    for i, device in enumerate(input_list):
+        if str(device).lower() != 'c':
+            device_list.append("cuda:" + str(device))
+        else:
+            device_list.append("cpu")
+    return device_list
+	
+# Split network into chunks
+def split_net(net, device_splits):		
+    chunks, cur_chunk = [], nn.Sequential()
+    for i, l in enumerate(net):
+         cur_chunk.add_module(str(i), net[i])
+         if str(i) in device_splits and device_splits != '':
+             del device_splits[0]
+             chunks.append(cur_chunk)
+             cur_chunk = nn.Sequential()
+    return chunks.append(cur_chunk)
+		
+# Put net chunks onto devices
+def chunks_to_devices(chunks, device_list):
+    for i, chunk in enumerate(chunks):
+        chunk.to(device_list[i])
+    return chunks
+	
+    
 class ModelParallel(nn.Module):
-    def __init__(self, chunks, device_list):
+    def __init__(self, net, devices, device_splits):
         super(ModelParallel, self).__init__()
-        self.chunks = chunks
-        self.device_list = device_list
+        self.device_list = name_devices(devices.split(','))		
+        self.chunks = chunks_to_devices(split_net(net, device_splits.split(',')), self.device_list)
 
     def c(self, input, i):
         if input.type() == 'torch.FloatTensor' and 'cuda' in self.device_list[i]:
@@ -122,7 +151,7 @@ class ModelParallel(nn.Module):
             else:
                 input = chunk(input)
         return input
-
+    
 
 
 def buildSequential(channel_list, pooling):

--- a/CaffeLoader.py
+++ b/CaffeLoader.py
@@ -101,8 +101,8 @@ class NIN(nn.Module):
             nn.Softmax(),
         )
 
-	
-			
+
+
 def name_devices(input_list):
     device_list = []
     for i, device in enumerate(input_list):
@@ -110,8 +110,8 @@ def name_devices(input_list):
             device_list.append("cuda:" + str(device))
         else:
             device_list.append("cpu")
-    return device_list	
-	
+    return device_list
+
 def split_net(net, net_splits):
     chunks, cur_chunk = [], nn.Sequential()
     for i, l in enumerate(net):
@@ -122,18 +122,18 @@ def split_net(net, net_splits):
             cur_chunk = nn.Sequential()
     chunks.append(cur_chunk)
     return chunks
-		
+
 def chunks_to_devices(chunks, device_list):
     for i, chunk in enumerate(chunks):
         chunk.to(device_list[i])
-    return chunks  
+    return chunks
 
 
 
 class ModelParallel(nn.Module):
     def __init__(self, net, device_ids, net_splits):
         super(ModelParallel, self).__init__()
-        self.device_list = name_devices(device_ids.split(','))		
+        self.device_list = name_devices(device_ids.split(','))
         self.chunks = chunks_to_devices(split_net(net, net_splits.split(',')), self.device_list)
 
     def c(self, input, i):
@@ -150,7 +150,7 @@ class ModelParallel(nn.Module):
             else:
                 input = chunk(input)
         return input
-    
+
 
 
 def buildSequential(channel_list, pooling):
@@ -238,7 +238,7 @@ def print_loadcaffe(cnn, layerList):
          if c == len(layerList['C']):
              break
 
-	
+
 # Load the model, and configure pooling layer type
 def loadCaffemodel(model_file, pooling, use_gpu, disable_check):
     cnn, layerList = modelSelector(str(model_file).lower(), pooling)

--- a/CaffeLoader.py
+++ b/CaffeLoader.py
@@ -122,7 +122,8 @@ def split_net(net, device_splits):
              del device_splits[0]
              chunks.append(cur_chunk)
              cur_chunk = nn.Sequential()
-    return chunks.append(cur_chunk)
+    chunks.append(cur_chunk)
+    return chunks
 		
 # Put net chunks onto devices
 def chunks_to_devices(chunks, device_list):

--- a/CaffeLoader.py
+++ b/CaffeLoader.py
@@ -108,7 +108,7 @@ class ModelParallel(nn.Module):
         Splits a sequential network across multiple devices.
     
 	Args:
-            net (Module): model to be split across multiple devices
+            net (Module): a sequential model to be split across multiple devices
             device_ids (list) list of zero-indexed GPU int and str c for CPU
             net_splits (int or list of int): int or list of layer indices of where to split net
 	    
@@ -123,11 +123,12 @@ class ModelParallel(nn.Module):
         self.device_list = name_devices(device_ids.split(','))		
         self.chunks = chunks_to_devices(split_net(net, net_splits.split(',')), self.device_list)
 
+	
     def name_devices(input_list):
-	r"""Convert a list of zero-indexed GPU and CPU devices to their PyTorch names
+	r"""Convert a list of zero-indexed GPU and CPU devices to their PyTorch names.
 	
         Arguments:
-            input_list (list): List of zero-indexed GPU devices, and 'c' for CPU.
+            input_list (list): List of zero-indexed GPU devices, and 'c' for CPU
         """
 	
         device_list = []
@@ -138,8 +139,16 @@ class ModelParallel(nn.Module):
                 device_list.append("cpu")
         return device_list
 	
+	
     # Split a network into chunks
-    def split_net(net, net_splits):		
+    def split_net(net, net_splits):
+	r"""Split a sequential net in chunks.
+	
+        Arguments:
+            net (list): A list of Sequential nets.
+	    net_splits (int or list of int): Layer indices of where to split net 
+        """
+	
         chunks, cur_chunk = [], nn.Sequential()
         for i, l in enumerate(net):
             cur_chunk.add_module(str(i), net[i])
@@ -150,11 +159,12 @@ class ModelParallel(nn.Module):
         chunks.append(cur_chunk)
         return chunks
 	
+	
     def chunks_to_devices(chunks, device_list):
 	r"""Put a list of Sequential nets onto different devices.
 	
         Arguments:
-            chunks (list of networks): A list of Sequential nets.
+            chunks (list): A list of Sequential nets.
 	    device_list (list of string): A list of PyTorch device names 
         """
 	
@@ -162,8 +172,9 @@ class ModelParallel(nn.Module):
             chunk.to(device_list[i])
         return chunks
 
+
     def c(self, input, i):
-	r"""Convert a tensor to the input device's backend.
+	r"""Convert a tensor to a device from self.device_list's backend.
 	
         Arguments:
             input (Tensor): A float or CUDA tensor.
@@ -175,6 +186,7 @@ class ModelParallel(nn.Module):
         elif input.type() == 'torch.cuda.FloatTensor' and 'cpu' in self.device_list[i]:
             input = input.type('torch.FloatTensor')
         return input
+
 
     def forward(self, input):
         for i, chunk in enumerate(self.chunks):

--- a/CaffeLoader.py
+++ b/CaffeLoader.py
@@ -104,51 +104,22 @@ class NIN(nn.Module):
 			
     
 class ModelParallel(nn.Module):
-    r"""
-        Splits a sequential network across multiple devices.
-    
-	Args:
-            net (Module): a sequential model to be split across multiple devices
-            device_ids (list) list of zero-indexed GPU int and str c for CPU
-            net_splits (int or list of int): int or list of layer indices of where to split net
-	    
-	Example::
-
-        >>> net = ModelParallel(model, device_ids=[0, 1, 2], net_splits=[2,5])
-        >>> net = ModelParallel(model, device_ids=[c, 0], net_splits=[5]) # c is used for CPU ID
-    """
-	
     def __init__(self, net, device_ids, net_splits):
         super(ModelParallel, self).__init__()
         self.device_list = name_devices(device_ids.split(','))		
         self.chunks = chunks_to_devices(split_net(net, net_splits.split(',')), self.device_list)
-
 	
     def name_devices(input_list):
-	r"""Convert a list of zero-indexed GPU and CPU devices to their PyTorch names.
-	
-        Arguments:
-            input_list (list): List of zero-indexed GPU devices, and 'c' for CPU
-        """
-	
         device_list = []
         for i, device in enumerate(input_list):
             if str(device).lower() != 'c':
                 device_list.append("cuda:" + str(device))
             else:
                 device_list.append("cpu")
-        return device_list
-	
+        return device_list	
 	
     # Split a network into chunks
     def split_net(net, net_splits):
-	r"""Split a sequential net in chunks.
-	
-        Arguments:
-            net (list): A list of Sequential nets.
-	    net_splits (int or list of int): Layer indices of where to split net 
-        """
-	
         chunks, cur_chunk = [], nn.Sequential()
         for i, l in enumerate(net):
             cur_chunk.add_module(str(i), net[i])
@@ -158,35 +129,18 @@ class ModelParallel(nn.Module):
                 cur_chunk = nn.Sequential()
         chunks.append(cur_chunk)
         return chunks
-	
-	
+		
     def chunks_to_devices(chunks, device_list):
-	r"""Put a list of Sequential nets onto different devices.
-	
-        Arguments:
-            chunks (list): A list of Sequential nets.
-	    device_list (list of string): A list of PyTorch device names 
-        """
-	
         for i, chunk in enumerate(chunks):
             chunk.to(device_list[i])
         return chunks
 
-
     def c(self, input, i):
-	r"""Convert a tensor to a device from self.device_list's backend.
-	
-        Arguments:
-            input (Tensor): A float or CUDA tensor.
-	    i (int): An index value for self.device_list.  
-        """
-	
         if input.type() == 'torch.FloatTensor' and 'cuda' in self.device_list[i]:
             input = input.type('torch.cuda.FloatTensor')
         elif input.type() == 'torch.cuda.FloatTensor' and 'cpu' in self.device_list[i]:
             input = input.type('torch.FloatTensor')
         return input
-
 
     def forward(self, input):
         for i, chunk in enumerate(self.chunks):

--- a/CaffeLoader.py
+++ b/CaffeLoader.py
@@ -101,39 +101,40 @@ class NIN(nn.Module):
             nn.Softmax(),
         )
 
+	
 			
-    
+def name_devices(input_list):
+    device_list = []
+    for i, device in enumerate(input_list):
+        if str(device).lower() != 'c':
+            device_list.append("cuda:" + str(device))
+        else:
+            device_list.append("cpu")
+    return device_list	
+	
+def split_net(net, net_splits):
+    chunks, cur_chunk = [], nn.Sequential()
+    for i, l in enumerate(net):
+        cur_chunk.add_module(str(i), net[i])
+        if str(i) in net_splits and net_splits != '':
+            del net_splits[0]
+            chunks.append(cur_chunk)
+            cur_chunk = nn.Sequential()
+    chunks.append(cur_chunk)
+    return chunks
+		
+def chunks_to_devices(chunks, device_list):
+    for i, chunk in enumerate(chunks):
+        chunk.to(device_list[i])
+    return chunks  
+
+
+
 class ModelParallel(nn.Module):
     def __init__(self, net, device_ids, net_splits):
         super(ModelParallel, self).__init__()
         self.device_list = name_devices(device_ids.split(','))		
         self.chunks = chunks_to_devices(split_net(net, net_splits.split(',')), self.device_list)
-	
-    def name_devices(input_list):
-        device_list = []
-        for i, device in enumerate(input_list):
-            if str(device).lower() != 'c':
-                device_list.append("cuda:" + str(device))
-            else:
-                device_list.append("cpu")
-        return device_list	
-	
-    # Split a network into chunks
-    def split_net(net, net_splits):
-        chunks, cur_chunk = [], nn.Sequential()
-        for i, l in enumerate(net):
-            cur_chunk.add_module(str(i), net[i])
-            if str(i) in net_splits and net_splits != '':
-                del net_splits[0]
-                chunks.append(cur_chunk)
-                cur_chunk = nn.Sequential()
-        chunks.append(cur_chunk)
-        return chunks
-		
-    def chunks_to_devices(chunks, device_list):
-        for i, chunk in enumerate(chunks):
-            chunk.to(device_list[i])
-        return chunks
 
     def c(self, input, i):
         if input.type() == 'torch.FloatTensor' and 'cuda' in self.device_list[i]:

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ The original [VGG-16 model](https://gist.github.com/ksimonyan/211839e770f7b538e2
 
 If you have a smaller memory GPU then using NIN Imagenet model will be better and gives slightly worse yet comparable results. You can get the details on the model from [BVLC Caffe ModelZoo](https://github.com/BVLC/caffe/wiki/Model-Zoo). The NIN model is downloaded when you run the `download_models.py` script.
 
-You can find detailed installation instructions for Ubuntu in the [installation guide](INSTALL.md).
+You can find detailed installation instructions for Ubuntu and Windows in the [installation guide](INSTALL.md).
 
 ## Usage
 Basic usage:

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ path or a full absolute path.
   the option is here.
 * `-seed`: An integer value that you can specify for repeatable results. By default this value is random for each run.
 * `-multidevice_strategy`: A comma-separated list of layer indices at which to split the network when using multiple devices. See [Multi-GPU scaling](https://github.com/ProGamerGov/neural-style-pt#multi-gpu-scaling) for more details.
-* `-backend`: `nn`, `cudnn`, or `mkl`. Default is `nn`.
+* `-backend`: `nn`, `cudnn`, `openmp`, or `mkl`. Default is `nn`. You can use `cudnn` and `mkl` together, separated by a comma. 
   `mkl` requires Intel's MKL backend.
 * `-cudnn_autotune`: When using the cuDNN backend, pass this flag to use the built-in cuDNN autotuner to select
   the best convolution algorithms for your architecture. This will make the first iteration a bit slower and can

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ path or a full absolute path.
   the option is here.
 * `-seed`: An integer value that you can specify for repeatable results. By default this value is random for each run.
 * `-multidevice_strategy`: A comma-separated list of layer indices at which to split the network when using multiple devices. See [Multi-GPU scaling](https://github.com/ProGamerGov/neural-style-pt#multi-gpu-scaling) for more details.
-* `-backend`: `nn`, `cudnn`, `openmp`, or `mkl`. Default is `nn`. `mkl` requires Intel's MKL backend. You can use `cudnn` and `mkl` together, separated by a comma.
+* `-backend`: `nn`, `cudnn`, `openmp`, or `mkl`. Default is `nn`. `mkl` requires Intel's MKL backend.
 * `-cudnn_autotune`: When using the cuDNN backend, pass this flag to use the built-in cuDNN autotuner to select
   the best convolution algorithms for your architecture. This will make the first iteration a bit slower and can
   take a bit more memory, but may significantly speed up the cuDNN backend.

--- a/README.md
+++ b/README.md
@@ -217,8 +217,7 @@ path or a full absolute path.
   the option is here.
 * `-seed`: An integer value that you can specify for repeatable results. By default this value is random for each run.
 * `-multidevice_strategy`: A comma-separated list of layer indices at which to split the network when using multiple devices. See [Multi-GPU scaling](https://github.com/ProGamerGov/neural-style-pt#multi-gpu-scaling) for more details.
-* `-backend`: `nn`, `cudnn`, `openmp`, or `mkl`. Default is `nn`. You can use `cudnn` and `mkl` together, separated by a comma. 
-  `mkl` requires Intel's MKL backend.
+* `-backend`: `nn`, `cudnn`, `openmp`, or `mkl`. Default is `nn`. `mkl` requires Intel's MKL backend. You can use `cudnn` and `mkl` together, separated by a comma.
 * `-cudnn_autotune`: When using the cuDNN backend, pass this flag to use the built-in cuDNN autotuner to select
   the best convolution algorithms for your architecture. This will make the first iteration a bit slower and can
   take a bit more memory, but may significantly speed up the cuDNN backend.

--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@ Optional dependencies:
   * cuDNN v6 or above
 * For ROCm backend:
   * ROCm 2.1 or above
+* For MKL backend:
+  * MKL 2019 or above
+* For OpenMP backend:
+  * OpenMP 5.0 or above
 
 After installing the dependencies, you'll need to run the following script to download the VGG model:
 ```

--- a/neural_style.py
+++ b/neural_style.py
@@ -39,7 +39,7 @@ parser.add_argument("-original_colors", type=int, choices=[0, 1], default=0)
 parser.add_argument("-pooling", choices=['avg', 'max'], default='max')
 parser.add_argument("-model_file", type=str, default='models/vgg19-d01eb7cb.pth')
 parser.add_argument("-disable_check", action='store_true')
-parser.add_argument("-backend", choices=['nn', 'cudnn', 'mkl', 'mkl,cudnn', 'cudnn,mkl'], default='nn')
+parser.add_argument("-backend", choices=['nn', 'cudnn', 'mkl', 'mkldnn', 'openmp', 'mkl,cudnn', 'cudnn,mkl'], default='nn')
 parser.add_argument("-cudnn_autotune", action='store_true')
 parser.add_argument("-seed", type=int, default=-1)
 
@@ -289,6 +289,10 @@ def setup_gpu():
     def setup_cpu():
        if 'mkl' in params.backend:
            torch.backends.mkl.enabled = True
+       elif 'mkldnn' in params.backend:
+           print("MKLDNN is not supported yet.")
+       elif 'openmp' in params.backend:
+           torch.backends.openmp.enabled = True           
 
     multidevice = False
     if "," in str(params.gpu):

--- a/neural_style.py
+++ b/neural_style.py
@@ -290,7 +290,7 @@ def setup_gpu():
        if 'mkl' in params.backend:
            torch.backends.mkl.enabled = True
        elif 'mkldnn' in params.backend:
-           print("MKLDNN is not supported yet.")
+           print("MKL-DNN is not supported yet.")
        elif 'openmp' in params.backend:
            torch.backends.openmp.enabled = True           
 

--- a/neural_style.py
+++ b/neural_style.py
@@ -290,7 +290,7 @@ def setup_gpu():
        if 'mkl' in params.backend:
            torch.backends.mkl.enabled = True
        elif 'mkldnn' in params.backend:
-           print("MKL-DNN is not supported yet.")
+           raise ValueError("MKL-DNN is not supported yet.")
        elif 'openmp' in params.backend:
            torch.backends.openmp.enabled = True           
 

--- a/neural_style.py
+++ b/neural_style.py
@@ -40,6 +40,7 @@ parser.add_argument("-pooling", choices=['avg', 'max'], default='max')
 parser.add_argument("-model_file", type=str, default='models/vgg19-d01eb7cb.pth')
 parser.add_argument("-disable_check", action='store_true')
 parser.add_argument("-backend", choices=['nn', 'cudnn', 'mkl', 'mkl,cudnn', 'cudnn,mkl'], default='nn')
+#parser.add_argument('-backend', choices=['nn', 'cudnn', 'mkl'], default='nn', nargs='*')
 parser.add_argument("-cudnn_autotune", action='store_true')
 parser.add_argument("-seed", type=int, default=-1)
 

--- a/neural_style.py
+++ b/neural_style.py
@@ -40,7 +40,6 @@ parser.add_argument("-pooling", choices=['avg', 'max'], default='max')
 parser.add_argument("-model_file", type=str, default='models/vgg19-d01eb7cb.pth')
 parser.add_argument("-disable_check", action='store_true')
 parser.add_argument("-backend", choices=['nn', 'cudnn', 'mkl', 'mkl,cudnn', 'cudnn,mkl'], default='nn')
-#parser.add_argument('-backend', choices=['nn', 'cudnn', 'mkl'], default='nn', nargs='*')
 parser.add_argument("-cudnn_autotune", action='store_true')
 parser.add_argument("-seed", type=int, default=-1)
 

--- a/neural_style.py
+++ b/neural_style.py
@@ -287,7 +287,7 @@ def setup_gpu():
             torch.backends.cudnn.enabled = False
 
     def setup_cpu():
-       if 'mkl' in params.backend:
+       if 'mkl' in params.backend and 'mkldnn' not in params.backend:
            torch.backends.mkl.enabled = True
        elif 'mkldnn' in params.backend:
            raise ValueError("MKL-DNN is not supported yet.")

--- a/neural_style.py
+++ b/neural_style.py
@@ -314,7 +314,7 @@ def setup_gpu():
 
 def setup_multi_device(net):
     assert len(params.gpu.split(',')) - 1 == len(params.multidevice_strategy.split(',')), \
-      "The number of -multidevice_strategy layer indices must be equal to the number of -gpu devices minus 1."
+      "The number of -multidevice_strategy layer indices minus 1, must be equal to the number of -gpu devices."
 
     new_net = ModelParallel(net, params.gpu, params.multidevice_strategy)
     return new_net

--- a/neural_style.py
+++ b/neural_style.py
@@ -292,7 +292,7 @@ def setup_gpu():
        elif 'mkldnn' in params.backend:
            raise ValueError("MKL-DNN is not supported yet.")
        elif 'openmp' in params.backend:
-           torch.backends.openmp.enabled = True           
+           torch.backends.openmp.enabled = True
 
     multidevice = False
     if "," in str(params.gpu):

--- a/neural_style.py
+++ b/neural_style.py
@@ -197,7 +197,7 @@ def main():
             img = init_image.clone()
         else:
             img = content_image.clone()
-    img = nn.Parameter(img.type(dtype))
+    img = nn.Parameter(img)
 
     def maybe_print(t, loss):
         if params.print_iter > 0 and t % params.print_iter == 0:

--- a/neural_style.py
+++ b/neural_style.py
@@ -308,13 +308,13 @@ def setup_gpu():
         setup_cuda()
         dtype, backward_device = torch.cuda.FloatTensor, "cuda:" + str(params.gpu)
     else:
-       setup_cpu()
-       dtype, backward_device = torch.FloatTensor, "cpu"
+        setup_cpu()
+        dtype, backward_device = torch.FloatTensor, "cpu"
     return dtype, multidevice, backward_device
 
 
 def setup_multi_device(net):
-    assert len(params.gpu) - 1 == len(params.multidevice_strategy.split(',')), \
+    assert len(params.gpu.split(',')) - 1 == len(params.multidevice_strategy.split(',')), \
       "The number of -multidevice_strategy layer indices must be equal to the number of -gpu devices minus 1."
 
     new_net = ModelParallel(net, params.gpu, params.multidevice_strategy)


### PR DESCRIPTION
- Better ModelParallel code.

- The `cudnn` and `mkl` backends can now be used at the same time with `-backend cudnn,mkl` or `-backend mkl,cudnn` (order doesn't matter). This can be useful for speeding up multi device usage that includes both a CPU and GPU. 

- If the CPU is not selected with the `-gpu` parameter, then CPU backends will be ignored.

- Added support for the OpenMP backend, via `-backend openmp`. 

- Initial support for MKL-DNN, so that it can be easily added when it becomes available in the next PyTorch release.

- Improved multi-device error messages.